### PR TITLE
Fix migration

### DIFF
--- a/db/migrate/20200621005543_devise_create_users.rb
+++ b/db/migrate/20200621005543_devise_create_users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DeviseCreateUsers < ActiveRecord::Migration[5.2]
+class DeviseCreateUsers < ActiveRecord::Migration[5.0]
   def change
     create_table :users do |t|
       ## Database authenticatable

--- a/db/migrate/20200623065830_create_addresses.rb
+++ b/db/migrate/20200623065830_create_addresses.rb
@@ -1,4 +1,4 @@
-class CreateAddresses < ActiveRecord::Migration[5.2]
+class CreateAddresses < ActiveRecord::Migration[5.0]
   def change
     create_table :addresses do |t|
       t.string     :first_name,      null: false

--- a/db/migrate/20200704132156_create_products.rb
+++ b/db/migrate/20200704132156_create_products.rb
@@ -1,4 +1,4 @@
-class CreateProducts < ActiveRecord::Migration[5.2]
+class CreateProducts < ActiveRecord::Migration[5.0]
   def change
     create_table :products do |t|
       t.string     :name

--- a/db/migrate/20200704132205_create_images.rb
+++ b/db/migrate/20200704132205_create_images.rb
@@ -1,4 +1,4 @@
-class CreateImages < ActiveRecord::Migration[5.2]
+class CreateImages < ActiveRecord::Migration[5.0]
   def change
     create_table :images do |t|
       t.references :product, foreign_key: true

--- a/db/migrate/20200705042143_create_categories.rb
+++ b/db/migrate/20200705042143_create_categories.rb
@@ -1,4 +1,4 @@
-class CreateCategories < ActiveRecord::Migration[5.2]
+class CreateCategories < ActiveRecord::Migration[5.0]
   def change
     create_table :categories do |t|
       t.string :name, null: false, index: true

--- a/db/migrate/20200707021404_create_accounts.rb
+++ b/db/migrate/20200707021404_create_accounts.rb
@@ -1,4 +1,4 @@
-class CreateAccounts < ActiveRecord::Migration[5.2]
+class CreateAccounts < ActiveRecord::Migration[5.0]
   def change
     create_table :accounts do |t|
       t.references :user,          null: false, forign_key: true

--- a/db/migrate/20200708130742_create_creditcards.rb
+++ b/db/migrate/20200708130742_create_creditcards.rb
@@ -1,4 +1,4 @@
-class CreateCreditcards < ActiveRecord::Migration[5.2]
+class CreateCreditcards < ActiveRecord::Migration[5.0]
   def change
     create_table :creditcards do |t|
       t.references :user,          null: false, forign_key: true

--- a/db/migrate/20200711111631_create_brands.rb
+++ b/db/migrate/20200711111631_create_brands.rb
@@ -1,4 +1,4 @@
-class CreateBrands < ActiveRecord::Migration[5.2]
+class CreateBrands < ActiveRecord::Migration[5.0]
   def change
     create_table :brands do |t|
       t.string :name, null: false, ndex: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -50,8 +50,7 @@ ActiveRecord::Schema.define(version: 2020_07_11_111631) do
     t.string "ancestry"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["ancestry"], name: "index_categories_on_ancestry"
-    t.index ["name"], name: "index_categories_on_name"
+    t.index ["name", "ancestry"], name: "index_categories_on_name_and_ancestry"
   end
 
   create_table "creditcards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -65,7 +64,7 @@ ActiveRecord::Schema.define(version: 2020_07_11_111631) do
 
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "product_id"
-    t.string "src", null: false
+    t.string "src"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["product_id"], name: "index_images_on_product_id"
@@ -81,11 +80,9 @@ ActiveRecord::Schema.define(version: 2020_07_11_111631) do
     t.integer "price"
     t.bigint "seller_id", null: false
     t.bigint "buyer_id"
-    t.bigint "category_id"
-    t.bigint "brand_id"
+    t.bigint "category_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["brand_id"], name: "index_products_on_brand_id"
     t.index ["buyer_id"], name: "index_products_on_buyer_id"
     t.index ["category_id"], name: "index_products_on_category_id"
     t.index ["seller_id"], name: "index_products_on_seller_id"
@@ -109,9 +106,7 @@ ActiveRecord::Schema.define(version: 2020_07_11_111631) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "addresses", "users"
   add_foreign_key "images", "products"
-  add_foreign_key "products", "brands"
   add_foreign_key "products", "categories"
   add_foreign_key "products", "users", column: "buyer_id"
   add_foreign_key "products", "users", column: "seller_id"


### PR DESCRIPTION
## Why

自動デプロイ時に外部キー不一致エラーが発生したため修正

## What

https://qiita.com/umeneri/items/b46c537661f612f7318b
https://qiita.com/aseanchild1400/items/87b89b55d596f6465fd6

記事を参考にActiveRecord::Migration[5.2]を[5.0]に変更