### PR TITLE
Add uniqueness constraint to name column of brands table

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,9 +226,9 @@
 -->
 
 ## brandsテーブル
-| Column | Type | Option    |
-|--------|------|-----------|
-|name    |string|index: true|
+| Column | Type | Option                  |
+|--------|------|-------------------------|
+|name    |string|index: true, unique: true|
 
 ### Association
 - has_many :products

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,5 +1,5 @@
 class Brand < ApplicationRecord
   has_many :products
 
-  validates :name, presence: true, length: { maximum: 40 }
+  validates :name, presence: true, uniqueness: true, length: { maximum: 40 }
 end

--- a/db/migrate/20200723194131_add_index_to_product.rb
+++ b/db/migrate/20200723194131_add_index_to_product.rb
@@ -1,4 +1,4 @@
-class AddIndexToProduct < ActiveRecord::Migration[5.2]
+class AddIndexToProduct < ActiveRecord::Migration[5.0]
   def change
     add_index :products, :name
   end

--- a/spec/models/brand_spec.rb
+++ b/spec/models/brand_spec.rb
@@ -19,5 +19,12 @@ RSpec.describe Brand, type: :model do
       expect(brand).to be_valid
       expect(brand.errors[:name]).not_to be_present
     end
+
+    it "追加したいブランド名がすでに存在する時は登録できないこと" do
+      brand1 = create(:brand, name: "brandA")
+      brand2 = build(:brand, name: "brandA")
+      expect(brand2).to be_invalid
+      expect(brand2.errors[:name]).to include("はすでに存在します")
+    end
   end
 end


### PR DESCRIPTION
#What
brandsテーブルのnameカラムに一意性制約を追加する。

#Why
現状の実装だと同名のブランドを無限に登録できてしまうため。