### PR TITLE
fix_breadcrumbs

### DIFF
--- a/app/assets/stylesheets/_breadcrumbs.scss
+++ b/app/assets/stylesheets/_breadcrumbs.scss
@@ -17,6 +17,7 @@
     a {
       text-decoration: none;
       cursor: pointer;
+      color: #000;
 
       &:visited {
         color: #000;


### PR DESCRIPTION
#What
パンクズの文字表示色を変更。
通常時、青っぽいのから黒に。

#Why
リンク踏み済みの色を黒に設定したが、未リンクの色を黒に設定していなかったため、わかりづらくなってしまったので、
リンクずみ、未リンク共に黒に統一。