### PR TITLE
Add all check btn

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -169,7 +169,9 @@ $(document).on('turbolinks:load', ()=> {
       <div class="detailed-search__contents__forms__form__label">
         <label for="q_category_id">孫カテゴリー</label>
       </div>
-      <div class="detailed-search__contents__forms__form__field">
+      <input type="checkbox" name="grandchild_all_check" id="grandchild_all_check" value="1" class="all-check-btn">
+      <label for="grandchild_all_check">全選択/全削除</label>
+      <div class="detailed-search__contents__forms__form__field" id="grandchild_check_boxes">
         <input type="hidden" name="q[category_id_in][]" value>
         ${insertHTML}
       </div>

--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -169,7 +169,7 @@ $(document).on('turbolinks:load', ()=> {
       <div class="detailed-search__contents__forms__form__label">
         <label for="q_category_id">孫カテゴリー</label>
       </div>
-      <input type="checkbox" name="grandchild_all_check" id="grandchild_all_check" value="1" class="all-check-btn">
+      <input type="checkbox" name="grandchild_all_check" id="grandchild_all_check" value="1">
       <label for="grandchild_all_check">全選択/全削除</label>
       <div class="detailed-search__contents__forms__form__field" id="grandchild_check_boxes">
         <input type="hidden" name="q[category_id_in][]" value>
@@ -245,6 +245,22 @@ $(document).on('turbolinks:load', ()=> {
     }
     else {  // 初期値になっている
       $('#grandchild-cat').remove();  // 一旦削除する
+    }
+  });
+
+  $('#cat').on('change', '#grandchild_all_check', function() {  // 全選択/全解除ボタンが押された
+    $('input[name="q[category_id_in][]"]').prop('checked', $(this).is(':checked'));  // 全選択の時全解除、全選択でない時全選択
+  });
+
+  $('#cat').on('change', $('input[name="q[category_id_in][]"]'), function() {  // 手動で変更された
+    const check = $('#grandchild_check_boxes :checked').length;
+    const input = $('#grandchild_check_boxes :input[type="checkbox"]').length;
+
+    if (check == input) {  // 全選択状態?
+      $('#grandchild_all_check').prop('checked', true);  // チェックを入れる
+    }
+    else {  // 全選択状態でない
+      $('#grandchild_all_check').prop('checked', false);  // チェックを外す
     }
   });
 });

--- a/app/assets/javascripts/product.js
+++ b/app/assets/javascripts/product.js
@@ -157,4 +157,65 @@ $(document).on('turbolinks:load', ()=> {
     let price = $(this).val();
     calculate(price);
   });
+
+
+
+
+
+  // 詳細検索 全選択/全解除ボタン
+  const condition_check_boxes = $('input[name="q[condition_id_in][]"]');
+  const costburden_check_boxes = $('input[name="q[costburden_id_in][]"]');
+  const shippingperiod_check_boxes = $('input[name="q[shippingperiod_id_in][]"]');
+
+  $('.all-check-btn').on('change', function() {  // 全選択/全解除ボタンが押された
+    switch ($(this).prop('id')) {
+      case 'condition_all_check':
+        condition_check_boxes.prop('checked', $(this).is(':checked'));  // 全選択の時全解除、全選択でない時全選択
+        break;
+      case 'costburden_all_check':
+        costburden_check_boxes.prop('checked', $(this).is(':checked'));  // 全選択の時全解除、全選択でない時全選択
+        break;
+      case 'shippingperiod_all_check':
+        shippingperiod_check_boxes.prop('checked', $(this).is(':checked'));  // 全選択の時全解除、全選択でない時全選択
+        break;
+      default:
+        ;
+    }
+  });
+
+  condition_check_boxes.on('change', function() {  // 手動で変更された
+    const check = $('#condition_check_boxes :checked').length;
+    const input = $('#condition_check_boxes :input[type="checkbox"]').length;
+
+    if (check == input) {  // 全選択状態?
+      $('#condition_all_check').prop('checked', true);  // チェックを入れる
+    }
+    else {  // 全選択状態でない
+      $('#condition_all_check').prop('checked', false);  // チェックを外す
+    }
+  });
+
+  costburden_check_boxes.on('change', function() {  // 手動で変更された
+    const check = $('#costburden_check_boxes :checked').length;
+    const input = $('#costburden_check_boxes :input[type="checkbox"]').length;
+
+    if (check == input) {  // 全選択状態?
+      $('#costburden_all_check').prop('checked', true);  // チェックを入れる
+    }
+    else {  // 全選択状態でない
+      $('#costburden_all_check').prop('checked', false);  // チェックを外す
+    }
+  });
+
+  shippingperiod_check_boxes.on('change', function() {  // 手動で変更された
+    const check = $('#shippingperiod_check_boxes :checked').length;
+    const input = $('#shippingperiod_check_boxes :input[type="checkbox"]').length;
+
+    if (check == input) {  // 全選択状態?
+      $('#shippingperiod_all_check').prop('checked', true);  // チェックを入れる
+    }
+    else {  // 全選択状態でない
+      $('#shippingperiod_all_check').prop('checked', false);  // チェックを外す
+    }
+  });
 });

--- a/app/assets/javascripts/product.js
+++ b/app/assets/javascripts/product.js
@@ -179,7 +179,7 @@ $(document).on('turbolinks:load', ()=> {
         shippingperiod_check_boxes.prop('checked', $(this).is(':checked'));  // 全選択の時全解除、全選択でない時全選択
         break;
       default:
-        ;
+        break;
     }
   });
 

--- a/app/views/products/partials/_search-form.html.haml
+++ b/app/views/products/partials/_search-form.html.haml
@@ -18,12 +18,16 @@
   .detailed-search__contents__forms__form
     .detailed-search__contents__forms__form__label
       = f.label :condition_id, '商品の状態'
-    .detailed-search__contents__forms__form__field
+    = check_box_tag :condition_all_check, 1, false, class: 'all-check-btn'
+    = label_tag :condition_all_check, "全選択/全解除"
+    #condition_check_boxes.detailed-search__contents__forms__form__field
       = f.collection_check_boxes :condition_id_in, Condition.all, :id, :name
   .detailed-search__contents__forms__form
     .detailed-search__contents__forms__form__label
       = f.label :costburden_id, '配送料の負担'
-    .detailed-search__contents__forms__form__field
+    = check_box_tag :costburden_all_check, 1, false, class: 'all-check-btn'
+    = label_tag :costburden_all_check, "全選択/全解除"
+    #costburden_check_boxes.detailed-search__contents__forms__form__field
       = f.collection_check_boxes :costburden_id_in, Costburden.all, :id, :name
   .detailed-search__contents__forms__form
     .detailed-search__contents__forms__form__label
@@ -33,7 +37,9 @@
   .detailed-search__contents__forms__form
     .detailed-search__contents__forms__form__label
       = f.label :shippingperiod_id, '発送までの日数'
-    .detailed-search__contents__forms__form__field
+    = check_box_tag :shippingperiod_all_check, 1, false, class: 'all-check-btn'
+    = label_tag :shippingperiod_all_check, "全選択/全解除"
+    #shippingperiod_check_boxes.detailed-search__contents__forms__form__field
       = f.collection_check_boxes :shippingperiod_id_in, Shippingperiod.all, :id, :name
   .detailed-search__contents__forms__form
     .detailed-search__contents__forms__form__label

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -120,9 +120,7 @@ ActiveRecord::Schema.define(version: 2020_08_02_051827) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "accounts", "users"
   add_foreign_key "addresses", "users"
-  add_foreign_key "creditcards", "users"
   add_foreign_key "images", "products"
   add_foreign_key "likes", "products"
   add_foreign_key "likes", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2020_08_02_051827) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_brands_on_name"
   end
 
   create_table "categories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -120,7 +121,9 @@ ActiveRecord::Schema.define(version: 2020_08_02_051827) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "accounts", "users"
   add_foreign_key "addresses", "users"
+  add_foreign_key "creditcards", "users"
   add_foreign_key "images", "products"
   add_foreign_key "likes", "products"
   add_foreign_key "likes", "users"


### PR DESCRIPTION
#What
詳細検索ページにおいて以下のチェックボックスに対して
全選択/全解除ボタンを実装する。
- 孫カテゴリー
- 商品の状態
- 配送料の負担
- 発送までの日数

#Why
複数のチェックボックスを全て選択したい時に
一つ一つチェックするのはユーザにとって手間であるため。