### PR TITLE
Add sales status form

### DIFF
--- a/app/assets/javascripts/product.js
+++ b/app/assets/javascripts/product.js
@@ -527,10 +527,79 @@ $(document).on('turbolinks:load', ()=> {
     window.location.href = current_html;  // 更新
   });
 
-  // ページ更新後のセレクトボックスを現在の状態に変える
+
+
+
+
+  // 販売状況ラジオボタン
+  $('input[type="radio"]').on('change', function() {  // ラジオボタンが変更された
+    const selected = $(this).attr('id');
+
+    switch (selected) {
+      case 'q_buyer_id_eq_':
+        $('#q_buyer_id_eq_').prop('checked', true);         // チェックを入れる
+        $('#q_buyer_id_null_true').prop('checked', false);  // チェックを外す
+        $('#q_buyer_id_gt_0').prop('checked', false);       // チェックを外す
+        break;
+      case 'q_buyer_id_null_true':
+        $('#q_buyer_id_eq_').prop('checked', false);       // チェックを外す
+        $('#q_buyer_id_null_true').prop('checked', true);  // チェックを入れる
+        $('#q_buyer_id_gt_0').prop('checked', false);      // チェックを外す
+        break;
+      case 'q_buyer_id_gt_0':
+        $('#q_buyer_id_eq_').prop('checked', false);        // チェックを外す
+        $('#q_buyer_id_null_true').prop('checked', false);  // チェックを外す
+        $('#q_buyer_id_gt_0').prop('checked', true);        // チェックを入れる
+        break;
+      default:
+        $('#q_buyer_id_eq_').prop('checked', true);         // チェックを入れる
+        $('#q_buyer_id_null_true').prop('checked', false);  // チェックを外す
+        $('#q_buyer_id_gt_0').prop('checked', false);       // チェックを外す
+        break;
+    }
+  });
+
+
+
+
+
+  // ページ更新後のフォームを現在の状態に変える
   $(function() {
     const current_html = window.location.href;  // urlを取得
+
+    // 販売状況ラジオボタン
+    if (current_html.match(/buyer_id_(eq|null|gt)/)) {
+      const selected = current_html.match(/buyer_id_(eq|null|gt)/)[0];
+
+      // urlから現在の並び順を推定しラジオボタンを変更する
+      switch (selected) {
+        case "buyer_id_eq":
+          $('#q_buyer_id_eq_').prop('checked', true);         // チェックを入れる
+          $('#q_buyer_id_null_true').prop('checked', false);  // チェックを外す
+          $('#q_buyer_id_gt_0').prop('checked', false);       // チェックを外す
+          break;
+        case "buyer_id_null":
+          $('#q_buyer_id_eq_').prop('checked', false);       // チェックを外す
+          $('#q_buyer_id_null_true').prop('checked', true);  // チェックを入れる
+          $('#q_buyer_id_gt_0').prop('checked', false);      // チェックを外す
+          break;
+        case "buyer_id_gt":
+          $('#q_buyer_id_eq_').prop('checked', false);        // チェックを外す
+          $('#q_buyer_id_null_true').prop('checked', false);  // チェックを外す
+          $('#q_buyer_id_gt_0').prop('checked', true);        // チェックを入れる
+          break;
+        default:
+          $('#q_buyer_id_eq_').prop('checked', true);         // チェックを入れる
+          $('#q_buyer_id_null_true').prop('checked', false);  // チェックを外す
+          $('#q_buyer_id_gt_0').prop('checked', false);       // チェックを外す
+          break;
+      }
+    }
+    else {
+      // nop
+    }
     
+    // 並べ替えセレクトボックス
     if (current_html.match(/&sort_order=(created_at|price|likes_count)\+(DESC|ASC)/)) {
       const current_order = current_html.match(/&sort_order=(created_at|price|likes_count)\+(DESC|ASC)/)[0];
 

--- a/app/views/products/partials/_search-form.html.haml
+++ b/app/views/products/partials/_search-form.html.haml
@@ -55,5 +55,15 @@
       〜
       ¥
       = f.number_field :price_lteq, placeholder: "Max"
+  .detailed-search__contents__forms__form
+    .detailed-search__contents__forms__form__label
+      = f.label :buyer_id, '販売状況'
+    .detailed-search__contents__forms__form__field
+      = f.radio_button :buyer_id_eq, '', checked: true
+      指定なし
+      = f.radio_button :buyer_id_null, 'true', checked: false
+      販売中
+      = f.radio_button :buyer_id_gt, 0, checked: false
+      売り切れ
   .detailed-search__contents__forms__submit-btn
     = f.submit '検索する'

--- a/app/views/products/partials/_search-form.html.haml
+++ b/app/views/products/partials/_search-form.html.haml
@@ -3,7 +3,7 @@
     .detailed-search__contents__forms__form__label
       並べ替え
     .detailed-search__contents__forms__form__field
-      = collection_select('', :sort_order, Sortorder.all, :value, :name, include_blank: '指定なし(出品日時の新しい順)')
+      = collection_select('', :sort_order, Sortorder.all, :value, :name)
   .detailed-search__contents__forms__form
     .detailed-search__contents__forms__form__label
       = f.label :name_or_explain, 'キーワード'


### PR DESCRIPTION
#What
詳細検索ページにて販売状況(販売中、売り切れ)によって表示する商品を限定できるようにする。

#Why
ユーザが目的の商品を探しやすくするため。